### PR TITLE
Add VAT filing helper demo UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>부가세 신고 도우미</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="app-header">
+    <h1>부가세 신고 도우미</h1>
+    <nav class="steps">
+      <span class="step is-active">1. 로그인</span>
+      <span class="step">2. 자료수집</span>
+      <span class="step">3. 검토</span>
+      <span class="step">4. 신고파일</span>
+      <span class="step">5. 홈택스 제출</span>
+    </nav>
+  </header>
+
+  <main class="container">
+    <!-- 섹션 A. 카카오 로그인 -->
+    <section id="login-section" class="card">
+      <h2>카카오로 시작</h2>
+      <p class="muted">사업자 확인과 알림 발송을 위해 카카오 로그인이 필요합니다.</p>
+      <button id="btnKakao" class="btn primary">카카오로 로그인</button>
+      <div id="loginStatus" class="status"></div>
+    </section>
+
+    <!-- 섹션 B. 약관/동의 -->
+    <section id="consent-section" class="card hidden">
+      <h2>동의 사항</h2>
+      <label class="checkbox"><input type="checkbox" id="agreeScrape" /> 홈택스 매출/매입 자료 수집에 동의합니다.</label>
+      <label class="checkbox"><input type="checkbox" id="agreePrivacy" /> 개인정보 처리방침에 동의합니다.</label>
+      <div class="row">
+        <button id="btnConsent" class="btn">동의하고 계속</button>
+      </div>
+    </section>
+
+    <!-- 섹션 C. 홈택스 인증 정보 입력(프록시/RPA 연동 전 단계) -->
+    <section id="hometax-section" class="card hidden">
+      <h2>홈택스 연결</h2>
+      <p class="muted">인증 방식 선택</p>
+      <div class="grid2">
+        <label class="radio"><input type="radio" name="authType" value="certificate" checked /> 공동/금융 인증서</label>
+        <label class="radio"><input type="radio" name="authType" value="idpw" /> 아이디/비밀번호</label>
+      </div>
+      <div class="row">
+        <button id="btnConnectHometax" class="btn">홈택스 연결 시도</button>
+        <span id="hometaxStatus" class="status"></span>
+      </div>
+      <p class="tip">실서비스에서는 이 버튼이 서버의 RPA/연동 API를 호출합니다.</p>
+    </section>
+
+    <!-- 섹션 D. 데이터 수집/프로그레스 -->
+    <section id="progress-section" class="card hidden">
+      <h2>자료 수집 진행상태</h2>
+      <progress id="scrapeProgress" value="0" max="100"></progress>
+      <div id="progressLog" class="log"></div>
+    </section>
+
+    <!-- 섹션 E. 데이터 미리보기 -->
+    <section id="preview-section" class="card hidden">
+      <h2>매출/매입 요약</h2>
+      <div class="grid2">
+        <div>
+          <h3>매출 합계</h3>
+          <div id="salesTotal" class="kpi">-</div>
+          <table id="salesTable" class="table"></table>
+        </div>
+        <div>
+          <h3>매입 합계</h3>
+          <div id="purchaseTotal" class="kpi">-</div>
+          <table id="purchaseTable" class="table"></table>
+        </div>
+      </div>
+      <div class="row">
+        <button id="btnMakeReturn" class="btn primary">부가가치세 신고서 생성</button>
+      </div>
+    </section>
+
+    <!-- 섹션 F. 신고서/전자파일 생성 -->
+    <section id="return-section" class="card hidden">
+      <h2>신고서 결과</h2>
+      <div class="grid2">
+        <div>
+          <h3>요약</h3>
+          <ul id="returnSummary" class="list"></ul>
+        </div>
+        <div>
+          <h3>전자파일</h3>
+          <button id="btnDownloadXml" class="btn">전자파일(XML) 다운로드</button>
+          <button id="btnDownloadPdf" class="btn">미리보기(PDF)</button>
+        </div>
+      </div>
+      <div class="row">
+        <button id="btnSubmitHometax" class="btn">홈택스에 신고</button>
+        <span id="submitStatus" class="status"></span>
+      </div>
+    </section>
+  </main>
+
+  <footer class="app-footer">
+    <small>ⓒ VAT Assistant</small>
+  </footer>
+
+  <!-- 카카오 SDK: 실제 키로 교체 필요 -->
+  <!-- <script src="https://developers.kakao.com/sdk/js/kakao.min.js"></script> -->
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,165 @@
+// 상태
+const state = {
+  user: null,
+  consent: { scrape: false, privacy: false },
+  sales: [],
+  purchases: [],
+  returnDoc: null,
+};
+
+// 유틸
+const $ = (sel) => document.querySelector(sel);
+const show = (selector, on = true) => {
+  const el = typeof selector === 'string' ? $(selector) : selector;
+  if (!el) return;
+  el.classList[on ? 'remove' : 'add']('hidden');
+};
+const formatKRW = (n) =>
+  new Intl.NumberFormat('ko-KR', { style: 'currency', currency: 'KRW' }).format(n || 0);
+
+// 로그인
+$('#btnKakao').addEventListener('click', async () => {
+  // 실제: Kakao.Auth.login으로 교체
+  state.user = { id: 'demo-user-1', name: '홍길동', phone: '010-0000-0000' };
+  $('#loginStatus').textContent = `${state.user.name} 로그인됨`;
+  document
+    .querySelectorAll('.step')
+    .forEach((s, i) => s.classList.toggle('is-active', i === 0));
+  show('#consent-section', true);
+});
+
+// 동의
+$('#btnConsent').addEventListener('click', () => {
+  state.consent.scrape = $('#agreeScrape').checked;
+  state.consent.privacy = $('#agreePrivacy').checked;
+  if (!(state.consent.scrape && state.consent.privacy)) return alert('모든 동의 항목을 체크하세요');
+  show('#hometax-section', true);
+});
+
+// 홈택스 연결 시뮬레이션
+$('#btnConnectHometax').addEventListener('click', async () => {
+  $('#hometaxStatus').textContent = '연결 시도 중';
+  await sleep(500);
+  $('#hometaxStatus').textContent = '인증 성공(데모)';
+  show('#progress-section', true);
+  startScrapeDemo();
+});
+
+// 스크래핑 진행 시뮬레이터
+async function startScrapeDemo() {
+  const log = (t) =>
+    ($('#progressLog').innerHTML += `<div>${new Date().toLocaleTimeString()} • ${t}</div>`);
+  for (let i = 0; i <= 100; i += 20) {
+    $('#scrapeProgress').value = i;
+    log(`${i}% 완료`);
+    await sleep(400);
+  }
+  // 데모 데이터
+  state.sales = [
+    { 구분: '전자세금계산서', 공급가액: 12_000_000, 세액: 1_200_000, 건수: 12 },
+    { 구분: '세금계산서', 공급가액: 3_000_000, 세액: 300_000, 건수: 3 },
+    { 구분: '카드', 공급가액: 5_000_000, 세액: 500_000, 건수: 50 },
+    { 구분: '현금영수증', 공급가액: 800_000, 세액: 80_000, 건수: 8 },
+    { 구분: '그외', 공급가액: 200_000, 세액: 20_000, 건수: 2 },
+  ];
+  state.purchases = [
+    { 구분: '전자세금계산서', 공급가액: 7_000_000, 세액: 700_000, 건수: 10 },
+    { 구분: '신용카드', 공급가액: 2_000_000, 세액: 200_000, 건수: 25 },
+    { 구분: '현금영수증', 공급가액: 600_000, 세액: 60_000, 건수: 7 },
+  ];
+  renderPreview();
+}
+
+function renderPreview() {
+  // 합계
+  const salesSum = state.sales.reduce((sum, row) => sum + row.공급가액 + row.세액, 0);
+  const purchSum = state.purchases.reduce((sum, row) => sum + row.공급가액 + row.세액, 0);
+  $('#salesTotal').textContent = formatKRW(salesSum);
+  $('#purchaseTotal').textContent = formatKRW(purchSum);
+
+  // 테이블 렌더
+  renderTable('#salesTable', ['구분', '공급가액', '세액', '건수'], state.sales);
+  renderTable('#purchaseTable', ['구분', '공급가액', '세액', '건수'], state.purchases);
+
+  // 다음 단계 노출
+  show('#preview-section', true);
+  document
+    .querySelectorAll('.step')
+    .forEach((s, i) => s.classList.toggle('is-active', i === 2));
+}
+
+$('#btnMakeReturn').addEventListener('click', () => {
+  const 매출세액 = state.sales.reduce((sum, row) => sum + row.세액, 0);
+  const 매입세액 = state.purchases.reduce((sum, row) => sum + row.세액, 0);
+  const 납부세액 = Math.max(0, 매출세액 - 매입세액);
+  state.returnDoc = { 매출세액, 매입세액, 납부세액 };
+  const ul = $('#returnSummary');
+  ul.innerHTML = '';
+  Object.entries(state.returnDoc).forEach(([key, value]) => {
+    const li = document.createElement('li');
+    li.textContent = `${key}: ${formatKRW(value)}`;
+    ul.appendChild(li);
+  });
+  show('#return-section', true);
+  document
+    .querySelectorAll('.step')
+    .forEach((s, i) => s.classList.toggle('is-active', i === 3));
+});
+
+$('#btnDownloadXml').addEventListener('click', () => {
+  // 실제: 서버에서 생성된 전자신고 XML을 다운로드
+  alert('데모: XML 생성은 서버 구현 필요');
+});
+
+$('#btnDownloadPdf').addEventListener('click', () => {
+  // 실제: 서버 PDF 미리보기
+  window.print();
+});
+
+$('#btnSubmitHometax').addEventListener('click', async () => {
+  $('#submitStatus').textContent = '제출 중(데모)';
+  await sleep(800);
+  $('#submitStatus').textContent = '제출 완료(데모)';
+  document
+    .querySelectorAll('.step')
+    .forEach((s, i) => s.classList.toggle('is-active', i === 4));
+});
+
+function renderTable(selector, headers, rows) {
+  const el = typeof selector === 'string' ? $(selector) : selector;
+  if (!el) return;
+  el.innerHTML = '';
+
+  const thead = document.createElement('thead');
+  const headerRow = document.createElement('tr');
+  headers.forEach((header) => {
+    const th = document.createElement('th');
+    th.textContent = header;
+    headerRow.appendChild(th);
+  });
+  thead.appendChild(headerRow);
+
+  const tbody = document.createElement('tbody');
+  rows.forEach((row) => {
+    const tr = document.createElement('tr');
+    headers.forEach((header) => {
+      const td = document.createElement('td');
+      if (header in row) {
+        const value = row[header];
+        td.textContent =
+          typeof value === 'number' ? formatKRW(value).replace('₩', '') : String(value);
+      } else {
+        td.textContent = '';
+      }
+      tr.appendChild(td);
+    });
+    tbody.appendChild(tr);
+  });
+
+  el.appendChild(thead);
+  el.appendChild(tbody);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,161 @@
+:root {
+  --bg: #0b0c10;
+  --card: #15171c;
+  --text: #e8eaed;
+  --muted: #9aa0a6;
+  --primary: #4f8cff;
+  --border: #2a2d33;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font: 14px/1.6 system-ui, -apple-system, "Segoe UI", Roboto;
+}
+
+.app-header {
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.app-header h1 {
+  font-size: 18px;
+  margin: 0;
+}
+
+.steps {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.step {
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--muted);
+}
+
+.step.is-active {
+  border-color: var(--primary);
+  color: var(--primary);
+}
+
+.container {
+  max-width: 1100px;
+  margin: 24px auto;
+  padding: 0 16px;
+  display: grid;
+  gap: 16px;
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 16px;
+}
+
+.hidden {
+  display: none;
+}
+
+.row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-top: 8px;
+}
+
+.grid2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.btn {
+  border: 1px solid var(--border);
+  background: #1c2128;
+  color: var(--text);
+  padding: 10px 14px;
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.btn.primary {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: #fff;
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.status {
+  margin-left: 8px;
+  color: var(--muted);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 8px;
+}
+
+.table th,
+.table td {
+  border-bottom: 1px solid var(--border);
+  padding: 8px;
+  text-align: left;
+}
+
+.kpi {
+  font-size: 24px;
+  font-weight: 700;
+  margin: 4px 0;
+}
+
+.log {
+  height: 100px;
+  overflow: auto;
+  border: 1px dashed var(--border);
+  padding: 8px;
+  border-radius: 8px;
+  background: #0f1115;
+}
+
+.list {
+  margin: 0;
+  padding-left: 16px;
+}
+
+.checkbox input,
+.radio input {
+  margin-right: 8px;
+}
+
+.tip {
+  color: var(--muted);
+  font-size: 12px;
+  margin-top: 8px;
+}
+
+.app-footer {
+  border-top: 1px solid var(--border);
+  padding: 12px 20px;
+  color: var(--muted);
+}


### PR DESCRIPTION
## Summary
- add VAT assistant single-page flow with login, consent, scraping, and filing sections
- include dark theme styling matching stepper and cards
- implement demo interactions and mock data for preview, filing summary, and downloads

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e6100dff00832a986d946907ced74f