### PR TITLE
Rebuild mobile VAT helper screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,75 @@
       </div>
 
       <section id="accountList" class="account-list"></section>
+
+      <section class="workflow">
+        <div class="workflow-header">
+          <h2 class="workflow-title">부가세 신고 도우미</h2>
+          <p class="workflow-subtitle">동의를 완료하면 홈택스 자료 수집과 신고서 생성 과정을 차례대로 안내해 드려요.</p>
+        </div>
+
+        <section id="consent-section" class="workflow-card hidden">
+          <h3>동의 사항</h3>
+          <label class="wf-checkbox"><input type="checkbox" id="agreeScrape" /> 홈택스 매출/매입 자료 수집에 동의합니다.</label>
+          <label class="wf-checkbox"><input type="checkbox" id="agreePrivacy" /> 개인정보 처리방침에 동의합니다.</label>
+          <button id="btnConsent" class="wf-btn wf-btn-primary">동의하고 계속</button>
+        </section>
+
+        <section id="hometax-section" class="workflow-card hidden">
+          <h3>홈택스 연결</h3>
+          <p class="wf-muted">인증 방식 선택</p>
+          <div class="wf-radio-group">
+            <label class="wf-radio"><input type="radio" name="authType" value="certificate" checked /> 공동/금융 인증서</label>
+            <label class="wf-radio"><input type="radio" name="authType" value="idpw" /> 아이디/비밀번호</label>
+          </div>
+          <div class="wf-row">
+            <button id="btnConnectHometax" class="wf-btn wf-btn-secondary">홈택스 연결 시도</button>
+            <span id="hometaxStatus" class="wf-status"></span>
+          </div>
+          <p class="wf-tip">실서비스에서는 이 버튼이 서버의 RPA/연동 API를 호출합니다.</p>
+        </section>
+
+        <section id="progress-section" class="workflow-card hidden">
+          <h3>자료 수집 진행상태</h3>
+          <progress id="scrapeProgress" value="0" max="100" class="wf-progress"></progress>
+          <div id="progressLog" class="wf-log"></div>
+        </section>
+
+        <section id="preview-section" class="workflow-card hidden">
+          <h3>매출/매입 요약</h3>
+          <div class="wf-grid">
+            <div>
+              <h4>매출 합계</h4>
+              <div id="salesTotal" class="wf-kpi">-</div>
+              <table id="salesTable" class="wf-table"></table>
+            </div>
+            <div>
+              <h4>매입 합계</h4>
+              <div id="purchaseTotal" class="wf-kpi">-</div>
+              <table id="purchaseTable" class="wf-table"></table>
+            </div>
+          </div>
+          <button id="btnMakeReturn" class="wf-btn wf-btn-primary">부가가치세 신고서 생성</button>
+        </section>
+
+        <section id="return-section" class="workflow-card hidden">
+          <h3>신고서 결과</h3>
+          <div class="wf-grid">
+            <div>
+              <h4>요약</h4>
+              <ul id="returnSummary" class="wf-list"></ul>
+            </div>
+            <div class="wf-actions">
+              <button id="btnDownloadXml" class="wf-btn wf-btn-secondary">전자파일(XML) 다운로드</button>
+              <button id="btnDownloadPdf" class="wf-btn wf-btn-secondary">미리보기(PDF)</button>
+            </div>
+          </div>
+          <div class="wf-row">
+            <button id="btnSubmitHometax" class="wf-btn wf-btn-outline">홈택스에 신고</button>
+            <span id="submitStatus" class="wf-status"></span>
+          </div>
+        </section>
+      </section>
     </section>
   </main>
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>부가세 신고 도우미</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main class="app">
+    <section id="loginScreen" class="screen screen-login">
+      <div class="login-card">
+        <div class="login-brand">kakao</div>
+        <p class="login-title">계정과 비밀번호 입력 없이<br />카카오톡으로 로그인해 보세요.</p>
+        <button id="btnKakao" class="btn btn-kakao">카카오톡으로 로그인</button>
+        <div class="divider"><span>또는</span></div>
+        <p class="login-subtitle">계정 정보 입력으로도 로그인할 수 있어요.</p>
+        <label class="input-label" for="loginId">카카오메일 아이디, 이메일, 전화번호</label>
+        <input id="loginId" type="text" placeholder="아이디 또는 이메일" />
+        <label class="input-label" for="loginPw">비밀번호</label>
+        <input id="loginPw" type="password" placeholder="비밀번호" />
+        <label class="remember"><input id="keepLogin" type="checkbox" /> 로그인 상태 유지</label>
+        <button id="btnSignIn" class="btn btn-login">로그인</button>
+        <div class="login-links">
+          <a href="#">비밀번호 찾기</a>
+          <a href="#">계정 찾기</a>
+          <a href="#">회원가입</a>
+        </div>
+      </div>
+    </section>
+
+    <section id="dashboardScreen" class="screen screen-dashboard hidden">
+      <header class="dash-header">
+        <div class="dash-copy">
+          <p class="dash-subtitle">SAVETAX 히든머니</p>
+          <h1 class="dash-title"><span id="userName">대표님</span>의 환급을 도와드릴게요</h1>
+        </div>
+        <button class="btn btn-add">사업자 추가 +</button>
+      </header>
+
+      <div class="pill-tabs">
+        <button class="pill is-active">개인사업자</button>
+        <button class="pill">법인사업자</button>
+      </div>
+
+      <div class="notice">
+        <span class="notice-label">환급신청을 완료해 주세요</span>
+      </div>
+
+      <section id="accountList" class="account-list"></section>
+    </section>
+  </main>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,124 @@
+const state = {
+  user: null,
+  accounts: [
+    {
+      type: '개인사업자',
+      owner: '정지인 대표님',
+      amount: 1234567,
+      status: '환급 예상',
+      buttons: [
+        { label: '환급신청', style: 'btn-light' },
+        { label: '정기세 신고', style: 'btn-outline' }
+      ]
+    },
+    {
+      type: '개인사업자',
+      owner: '김유린 대표님',
+      amount: 1234567,
+      status: '환급 예정 D-70',
+      buttons: [
+        { label: '결제수단 등록', style: 'btn-tonal' }
+      ]
+    },
+    {
+      type: '개인사업자',
+      owner: '김아름 대표님',
+      amount: 1234567,
+      status: '환급 확정',
+      buttons: [
+        { label: '결제대기', style: 'btn-outline' },
+        { label: '입금계좌', style: 'btn-tonal' }
+      ]
+    },
+    {
+      type: '개인사업자',
+      owner: '강지윤 대표님',
+      amount: 1234567,
+      status: '환급 확정',
+      buttons: [
+        { label: '입금계좌', style: 'btn-tonal' }
+      ]
+    }
+  ]
+};
+
+const loginScreen = document.getElementById('loginScreen');
+const dashboardScreen = document.getElementById('dashboardScreen');
+const btnKakao = document.getElementById('btnKakao');
+const btnSignIn = document.getElementById('btnSignIn');
+const userName = document.getElementById('userName');
+const accountList = document.getElementById('accountList');
+
+btnKakao.addEventListener('click', () => {
+  completeLogin('홍길동');
+});
+
+btnSignIn.addEventListener('click', () => {
+  const name = document.getElementById('loginId').value.trim() || '대표님';
+  completeLogin(name);
+});
+
+function completeLogin(name) {
+  state.user = { name };
+  userName.textContent = state.user.name;
+  renderAccounts();
+  toggleScreens();
+}
+
+function toggleScreens() {
+  loginScreen.classList.add('hidden');
+  dashboardScreen.classList.remove('hidden');
+}
+
+function renderAccounts() {
+  accountList.innerHTML = '';
+  state.accounts.forEach((account) => {
+    const card = document.createElement('article');
+    card.className = 'account-card';
+
+    const meta = document.createElement('div');
+    meta.className = 'account-meta';
+    const badge = document.createElement('span');
+    badge.className = 'badge';
+    badge.textContent = account.type;
+    meta.appendChild(badge);
+    card.appendChild(meta);
+
+    const owner = document.createElement('div');
+    owner.className = 'account-owner';
+    owner.textContent = account.owner;
+    card.appendChild(owner);
+
+    const amount = document.createElement('div');
+    amount.className = 'account-amount';
+    amount.textContent = formatCurrency(account.amount);
+    card.appendChild(amount);
+
+    const status = document.createElement('div');
+    status.className = 'account-status';
+    status.textContent = account.status;
+    card.appendChild(status);
+
+    if (account.buttons?.length) {
+      const actions = document.createElement('div');
+      actions.className = 'account-actions';
+      account.buttons.forEach((btn) => {
+        const actionBtn = document.createElement('button');
+        actionBtn.className = btn.style;
+        actionBtn.textContent = btn.label;
+        actions.appendChild(actionBtn);
+      });
+      card.appendChild(actions);
+    }
+
+    accountList.appendChild(card);
+  });
+}
+
+function formatCurrency(value) {
+  return new Intl.NumberFormat('ko-KR', {
+    style: 'currency',
+    currency: 'KRW',
+    maximumFractionDigits: 0
+  }).format(value);
+}

--- a/script.js
+++ b/script.js
@@ -76,6 +76,7 @@ btnConsent.addEventListener('click', () => {
     alert('모든 동의 항목을 체크해 주세요.');
     return;
   }
+  show('#consent-section', false);
   show('#hometax-section', true);
 });
 
@@ -84,6 +85,7 @@ btnConnectHometax.addEventListener('click', async () => {
   status.textContent = '연결 시도 중';
   await sleep(500);
   status.textContent = '인증 성공(데모)';
+  show('#hometax-section', false);
   show('#progress-section', true);
   startScrapeDemo();
 });
@@ -106,6 +108,7 @@ btnMakeReturn.addEventListener('click', () => {
     summary.appendChild(li);
   });
 
+  show('#preview-section', false);
   show('#return-section', true);
 });
 
@@ -127,6 +130,9 @@ btnSubmitHometax.addEventListener('click', async () => {
 function completeLogin(name) {
   state.user = { name };
   userName.textContent = state.user.name;
+  document.getElementById('loginId').value = '';
+  document.getElementById('loginPw').value = '';
+  document.getElementById('keepLogin').checked = false;
   renderAccounts();
   toggleScreens();
   resetWorkflow();
@@ -273,6 +279,7 @@ function renderPreview() {
   table('#salesTable', ['구분', '공급가액', '세액', '건수'], state.sales);
   table('#purchaseTable', ['구분', '공급가액', '세액', '건수'], state.purchases);
 
+  show('#progress-section', false);
   show('#preview-section', true);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,308 @@
+:root {
+  --bg-body: #f5f6fb;
+  --bg-card: #ffffff;
+  --bg-kakao: #fee500;
+  --bg-primary: linear-gradient(180deg, #f8fbff 0%, #eef4ff 100%);
+  --text-main: #1b1d29;
+  --text-muted: #6f7385;
+  --accent: #3d63ff;
+  --pill-bg: rgba(61, 99, 255, 0.12);
+  --pill-text: #3d63ff;
+  --border-soft: #e5e8f0;
+  --shadow-soft: 0 20px 40px rgba(27, 29, 41, 0.08);
+  font-family: 'Pretendard', 'Apple SD Gothic Neo', 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg-body);
+  color: var(--text-main);
+}
+
+.app {
+  min-height: 100vh;
+}
+
+.screen {
+  min-height: 100vh;
+  padding: 24px 20px 40px;
+}
+
+.screen-login {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.login-card {
+  width: min(360px, 100%);
+  background: var(--bg-card);
+  border-radius: 28px;
+  padding: 32px 28px;
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.login-brand {
+  font-size: 22px;
+  font-weight: 700;
+  text-align: center;
+}
+
+.login-title {
+  margin: 0;
+  font-size: 18px;
+  line-height: 1.4;
+  text-align: center;
+}
+
+.login-subtitle {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
+.btn {
+  border: none;
+  border-radius: 14px;
+  font-size: 15px;
+  font-weight: 600;
+  padding: 15px;
+  cursor: pointer;
+}
+
+.btn-kakao {
+  background: var(--bg-kakao);
+  color: #191600;
+}
+
+.btn-login {
+  background: var(--accent);
+  color: #fff;
+}
+
+.btn-add {
+  background: rgba(255, 255, 255, 0.28);
+  color: #fff;
+  padding: 12px 16px;
+  font-size: 14px;
+  border-radius: 999px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
+}
+
+input[type="text"],
+input[type="password"] {
+  width: 100%;
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 1px solid var(--border-soft);
+  background: #fafbff;
+  font-size: 15px;
+}
+
+.input-label {
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.remember {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.login-links {
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+}
+
+.login-links a {
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.divider {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.divider::before,
+.divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--border-soft);
+}
+
+.screen-dashboard {
+  background: var(--bg-primary);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.dash-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.dash-subtitle {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
+.dash-title {
+  margin: 8px 0 0;
+  font-size: 24px;
+  line-height: 1.35;
+}
+
+.pill-tabs {
+  display: flex;
+  gap: 12px;
+}
+
+.pill {
+  flex: none;
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: #fff;
+  color: var(--text-muted);
+  font-size: 14px;
+  border: none;
+}
+
+.pill.is-active {
+  background: var(--pill-bg);
+  color: var(--pill-text);
+  font-weight: 600;
+}
+
+.notice {
+  background: #fff5ec;
+  padding: 14px 18px;
+  border-radius: 18px;
+  color: #ff7a00;
+  font-size: 13px;
+  align-self: flex-start;
+  box-shadow: 0 12px 30px rgba(255, 122, 0, 0.18);
+}
+
+.account-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.account-card {
+  background: var(--bg-card);
+  border-radius: 22px;
+  padding: 24px;
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.account-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.badge {
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  background: rgba(61, 99, 255, 0.12);
+  color: var(--pill-text);
+}
+
+.account-owner {
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.account-amount {
+  font-size: 28px;
+  font-weight: 700;
+}
+
+.account-status {
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.account-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.btn-light,
+.btn-outline,
+.btn-tonal {
+  flex: 1;
+  min-width: 140px;
+  padding: 12px;
+  border-radius: 14px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+}
+
+.btn-outline {
+  background: #f3f5ff;
+  color: var(--pill-text);
+}
+
+.btn-tonal {
+  background: #e7f7ff;
+  color: #0088cc;
+}
+
+.btn-light {
+  background: #fff7eb;
+  color: #f27a06;
+}
+
+.hidden {
+  display: none !important;
+}
+
+@media (min-width: 768px) {
+  .screen {
+    padding: 40px 48px 64px;
+  }
+
+  .dash-header {
+    align-items: center;
+  }
+
+  .account-list {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .account-card {
+    width: calc(50% - 8px);
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -288,6 +288,198 @@ input[type="password"] {
   display: none !important;
 }
 
+.workflow {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  margin-top: 8px;
+  padding-bottom: 48px;
+}
+
+.workflow-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.workflow-title {
+  margin: 0;
+  font-size: 20px;
+}
+
+.workflow-subtitle {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.workflow-card {
+  background: var(--bg-card);
+  border-radius: 20px;
+  padding: 22px 20px;
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.workflow-card h3,
+.workflow-card h4 {
+  margin: 0;
+}
+
+.wf-checkbox {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  font-size: 14px;
+  color: var(--text-main);
+}
+
+.wf-checkbox input {
+  margin-top: 3px;
+}
+
+.wf-radio-group {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.wf-radio {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  padding: 10px 14px;
+  border-radius: 14px;
+  background: #f3f4fb;
+}
+
+.wf-radio input {
+  margin: 0;
+}
+
+.wf-muted {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.wf-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.wf-status {
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.wf-tip {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.wf-btn {
+  border: none;
+  border-radius: 14px;
+  padding: 14px 18px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.wf-btn:active {
+  transform: translateY(1px);
+}
+
+.wf-btn-primary {
+  background: var(--accent);
+  color: #fff;
+}
+
+.wf-btn-secondary {
+  background: #eef2ff;
+  color: var(--pill-text);
+}
+
+.wf-btn-outline {
+  background: #fff;
+  color: var(--accent);
+  box-shadow: inset 0 0 0 1px rgba(61, 99, 255, 0.3);
+}
+
+.wf-progress {
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  overflow: hidden;
+  accent-color: var(--accent);
+}
+
+.wf-log {
+  min-height: 100px;
+  max-height: 160px;
+  overflow-y: auto;
+  border-radius: 14px;
+  padding: 12px;
+  background: #f6f8ff;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.wf-grid {
+  display: grid;
+  gap: 18px;
+}
+
+.wf-kpi {
+  font-size: 22px;
+  font-weight: 700;
+  margin: 4px 0 0;
+}
+
+.wf-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.wf-table th,
+.wf-table td {
+  text-align: left;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.wf-list {
+  margin: 0;
+  padding-left: 18px;
+  font-size: 14px;
+  color: var(--text-main);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.wf-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+@media (min-width: 600px) {
+  .wf-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 @media (min-width: 768px) {
   .screen {
     padding: 40px 48px 64px;


### PR DESCRIPTION
## Summary
- rebuild the landing markup to mirror the Kakao 모바일 로그인 구성 and drop the 단계 스텝 네비게이션
- refresh the mobile-first 스타일로 로그인 카드와 환급 대시보드 카드를 재구성
- add 간단한 스크립트로 로그인 후 대표님 이름과 샘플 계정을 그리도록 처리

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e6100dff00832a986d946907ced74f