### PR TITLE
Rebuild dashboard after login

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,98 +30,63 @@
     </section>
 
     <section id="dashboardScreen" class="screen screen-dashboard hidden">
-      <header class="dash-header">
-        <div class="dash-copy">
-          <p class="dash-subtitle">SAVETAX 히든머니</p>
-          <h1 class="dash-title"><span id="userName">대표님</span>의 환급을 도와드릴게요</h1>
+      <header class="company-header">
+        <div>
+          <p class="welcome" id="welcomeMessage">대표님, 환영해요!</p>
+          <h1 class="company-name" id="companyName">(주) 바이브코딩</h1>
+          <div class="company-info">
+            <span class="company-type" id="companyType">법인사업자</span>
+            <span class="company-reg-num" id="companyRegNum">123-45-67890</span>
+          </div>
         </div>
-        <button class="btn btn-add">사업자 추가 +</button>
+        <button class="btn btn-secondary" id="btnLogout">로그아웃</button>
       </header>
 
-      <div class="pill-tabs">
-        <button class="pill is-active">개인사업자</button>
-        <button class="pill">법인사업자</button>
-      </div>
-
-      <div class="notice">
-        <span class="notice-label">환급신청을 완료해 주세요</span>
-      </div>
-
-      <section id="accountList" class="account-list"></section>
-
-      <section class="workflow">
-        <div class="workflow-header">
-          <h2 class="workflow-title">부가세 신고 도우미</h2>
-          <p class="workflow-subtitle">동의를 완료하면 홈택스 자료 수집과 신고서 생성 과정을 차례대로 안내해 드려요.</p>
+      <section class="vat-report-section">
+        <h2 class="section-title">부가세 신고내역</h2>
+        <div class="vat-summary">
+          <div class="vat-item">
+            <span class="vat-label">신고기간</span>
+            <span class="vat-value" id="vatPeriod">-</span>
+          </div>
+          <div class="vat-item">
+            <span class="vat-label">신고금액</span>
+            <span class="vat-value amount" id="vatAmount">-</span>
+          </div>
+          <div class="vat-item">
+            <span class="vat-label">납부세액</span>
+            <span class="vat-value amount" id="vatTax">-</span>
+          </div>
+          <div class="vat-item">
+            <span class="vat-label">신고상태</span>
+            <span class="vat-value status" id="vatStatus">-</span>
+          </div>
         </div>
+        <button class="btn btn-primary">신고내역 상세보기</button>
+      </section>
 
-        <section id="consent-section" class="workflow-card hidden">
-          <h3>동의 사항</h3>
-          <label class="wf-checkbox"><input type="checkbox" id="agreeScrape" /> 홈택스 매출/매입 자료 수집에 동의합니다.</label>
-          <label class="wf-checkbox"><input type="checkbox" id="agreePrivacy" /> 개인정보 처리방침에 동의합니다.</label>
-          <button id="btnConsent" class="wf-btn wf-btn-primary">동의하고 계속</button>
-        </section>
+      <section class="sales-section">
+        <h2 class="section-title">매출 구분별 요약</h2>
+        <table class="sales-table" id="salesTable">
+          <thead>
+            <tr>
+              <th>구분</th>
+              <th>건수</th>
+              <th>공급가액</th>
+              <th>세액</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </section>
 
-        <section id="hometax-section" class="workflow-card hidden">
-          <h3>홈택스 연결</h3>
-          <p class="wf-muted">인증 방식 선택</p>
-          <div class="wf-radio-group">
-            <label class="wf-radio"><input type="radio" name="authType" value="certificate" checked /> 공동/금융 인증서</label>
-            <label class="wf-radio"><input type="radio" name="authType" value="idpw" /> 아이디/비밀번호</label>
-          </div>
-          <div class="wf-row">
-            <button id="btnConnectHometax" class="wf-btn wf-btn-secondary">홈택스 연결 시도</button>
-            <span id="hometaxStatus" class="wf-status"></span>
-          </div>
-          <p class="wf-tip">실서비스에서는 이 버튼이 서버의 RPA/연동 API를 호출합니다.</p>
-        </section>
-
-        <section id="progress-section" class="workflow-card hidden">
-          <h3>자료 수집 진행상태</h3>
-          <progress id="scrapeProgress" value="0" max="100" class="wf-progress"></progress>
-          <div id="progressLog" class="wf-log"></div>
-        </section>
-
-        <section id="preview-section" class="workflow-card hidden">
-          <h3>매출/매입 요약</h3>
-          <div class="wf-grid">
-            <div>
-              <h4>매출 합계</h4>
-              <div id="salesTotal" class="wf-kpi">-</div>
-              <table id="salesTable" class="wf-table"></table>
-            </div>
-            <div>
-              <h4>매입 합계</h4>
-              <div id="purchaseTotal" class="wf-kpi">-</div>
-              <table id="purchaseTable" class="wf-table"></table>
-            </div>
-          </div>
-          <button id="btnMakeReturn" class="wf-btn wf-btn-primary">부가가치세 신고서 생성</button>
-        </section>
-
-        <section id="return-section" class="workflow-card hidden">
-          <h3>신고서 결과</h3>
-          <div class="wf-grid">
-            <div>
-              <h4>요약</h4>
-              <ul id="returnSummary" class="wf-list"></ul>
-            </div>
-            <div class="wf-actions">
-              <button id="btnDownloadXml" class="wf-btn wf-btn-secondary">전자파일(XML) 다운로드</button>
-              <button id="btnDownloadPdf" class="wf-btn wf-btn-secondary">미리보기(PDF)</button>
-            </div>
-          </div>
-          <div class="wf-row">
-            <button id="btnSubmitHometax" class="wf-btn wf-btn-outline">홈택스에 신고</button>
-            <span id="submitStatus" class="wf-status"></span>
-          </div>
-        </section>
+      <section class="documents-section">
+        <h2 class="section-title">문서 및 매출 내역</h2>
+        <div class="documents-grid" id="documentsGrid"></div>
       </section>
     </section>
   </main>
 
-  <!-- 카카오 SDK 실제 키 적용 시 주석 해제 -->
-  <!-- <script src="https://developers.kakao.com/sdk/js/kakao.min.js"></script> -->
   <script src="script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -31,15 +31,11 @@
 
     <section id="dashboardScreen" class="screen screen-dashboard hidden">
       <header class="company-header">
-        <div>
-          <p class="welcome" id="welcomeMessage">대표님, 환영해요!</p>
-          <h1 class="company-name" id="companyName">(주) 바이브코딩</h1>
-          <div class="company-info">
-            <span class="company-type" id="companyType">법인사업자</span>
-            <span class="company-reg-num" id="companyRegNum">123-45-67890</span>
-          </div>
+        <h1 class="company-name">(주) 바이브코딩</h1>
+        <div class="company-info">
+          <span class="company-type">법인사업자</span>
+          <span class="company-reg-num">123-45-67890</span>
         </div>
-        <button class="btn btn-secondary" id="btnLogout">로그아웃</button>
       </header>
 
       <section class="vat-report-section">
@@ -47,42 +43,59 @@
         <div class="vat-summary">
           <div class="vat-item">
             <span class="vat-label">신고기간</span>
-            <span class="vat-value" id="vatPeriod">-</span>
+            <span class="vat-value">2024년 1분기</span>
           </div>
           <div class="vat-item">
             <span class="vat-label">신고금액</span>
-            <span class="vat-value amount" id="vatAmount">-</span>
+            <span class="vat-value amount">₩1,234,567</span>
           </div>
           <div class="vat-item">
             <span class="vat-label">납부세액</span>
-            <span class="vat-value amount" id="vatTax">-</span>
+            <span class="vat-value amount">₩123,456</span>
           </div>
           <div class="vat-item">
             <span class="vat-label">신고상태</span>
-            <span class="vat-value status" id="vatStatus">-</span>
+            <span class="vat-value status completed">신고완료</span>
           </div>
         </div>
         <button class="btn btn-primary">신고내역 상세보기</button>
       </section>
 
-      <section class="sales-section">
-        <h2 class="section-title">매출 구분별 요약</h2>
-        <table class="sales-table" id="salesTable">
-          <thead>
-            <tr>
-              <th>구분</th>
-              <th>건수</th>
-              <th>공급가액</th>
-              <th>세액</th>
-            </tr>
-          </thead>
-          <tbody></tbody>
-        </table>
-      </section>
-
       <section class="documents-section">
         <h2 class="section-title">문서 및 매출 내역</h2>
-        <div class="documents-grid" id="documentsGrid"></div>
+        <div class="documents-grid">
+          <div class="document-card">
+            <div class="document-icon">📄</div>
+            <h3 class="document-title">세금계산서</h3>
+            <div class="document-count">15건</div>
+            <div class="document-amount">₩2,345,678</div>
+            <button class="btn btn-outline">상세보기</button>
+          </div>
+
+          <div class="document-card">
+            <div class="document-icon">🧾</div>
+            <h3 class="document-title">계산서</h3>
+            <div class="document-count">8건</div>
+            <div class="document-amount">₩1,234,567</div>
+            <button class="btn btn-outline">상세보기</button>
+          </div>
+
+          <div class="document-card">
+            <div class="document-icon">💳</div>
+            <h3 class="document-title">카드매출</h3>
+            <div class="document-count">45건</div>
+            <div class="document-amount">₩4,567,890</div>
+            <button class="btn btn-outline">상세보기</button>
+          </div>
+
+          <div class="document-card">
+            <div class="document-icon">🧾</div>
+            <h3 class="document-title">현금영수증</h3>
+            <div class="document-count">23건</div>
+            <div class="document-amount">₩3,456,789</div>
+            <button class="btn btn-outline">상세보기</button>
+          </div>
+        </div>
       </section>
     </section>
   </main>

--- a/script.js
+++ b/script.js
@@ -1,158 +1,34 @@
-const state = {
-  user: null,
-  company: {
-    name: '(주) 바이브코딩',
-    type: '법인사업자',
-    regNum: '123-45-67890'
-  },
-  vat: {
-    period: '2024년 1분기',
-    amount: 1234567,
-    tax: 123456,
-    status: '신고완료'
-  },
-  sales: [
-    { 구분: '세금계산서', 건수: 15, 공급가액: 2345678, 세액: 234568 },
-    { 구분: '계산서', 건수: 8, 공급가액: 1234567, 세액: 123457 },
-    { 구분: '카드', 건수: 45, 공급가액: 4567890, 세액: 456789 },
-    { 구분: '현금영수증', 건수: 23, 공급가액: 3456789, 세액: 345679 },
-    { 구분: '그 외', 건수: 5, 공급가액: 456789, 세액: 45679 }
-  ]
-};
-
 const loginScreen = document.getElementById('loginScreen');
 const dashboardScreen = document.getElementById('dashboardScreen');
 const btnKakao = document.getElementById('btnKakao');
 const btnSignIn = document.getElementById('btnSignIn');
-const btnLogout = document.getElementById('btnLogout');
-
 const loginId = document.getElementById('loginId');
 const loginPw = document.getElementById('loginPw');
 const keepLogin = document.getElementById('keepLogin');
 
-const welcomeMessage = document.getElementById('welcomeMessage');
-const companyName = document.getElementById('companyName');
-const companyType = document.getElementById('companyType');
-const companyRegNum = document.getElementById('companyRegNum');
-const vatPeriod = document.getElementById('vatPeriod');
-const vatAmount = document.getElementById('vatAmount');
-const vatTax = document.getElementById('vatTax');
-const vatStatus = document.getElementById('vatStatus');
-const salesTableBody = document.querySelector('#salesTable tbody');
-const documentsGrid = document.getElementById('documentsGrid');
-
-btnKakao.addEventListener('click', () => completeLogin('카카오 사용자'));
+btnKakao.addEventListener('click', showDashboard);
 btnSignIn.addEventListener('click', () => {
-  const name = loginId.value.trim() || '대표님';
-  completeLogin(name);
+  showDashboard();
 });
 
-btnLogout.addEventListener('click', () => {
-  state.user = null;
-  loginId.value = '';
-  loginPw.value = '';
-  keepLogin.checked = false;
-  dashboardScreen.classList.add('hidden');
-  loginScreen.classList.remove('hidden');
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Enter' && !dashboardVisible()) {
+    showDashboard();
+  }
 });
 
-function completeLogin(name) {
-  state.user = { name };
-  welcomeMessage.textContent = `${state.user.name}님, 환영해요!`;
-  loginId.value = '';
-  loginPw.value = '';
-  keepLogin.checked = false;
-  renderDashboard();
-  toggleScreens();
-}
-
-function toggleScreens() {
+function showDashboard() {
+  clearLoginForm();
   loginScreen.classList.add('hidden');
   dashboardScreen.classList.remove('hidden');
 }
 
-function renderDashboard() {
-  companyName.textContent = state.company.name;
-  companyType.textContent = state.company.type;
-  companyRegNum.textContent = state.company.regNum;
-  vatPeriod.textContent = state.vat.period;
-  vatAmount.textContent = formatKRW(state.vat.amount);
-  vatTax.textContent = formatKRW(state.vat.tax);
-  vatStatus.textContent = state.vat.status;
-  renderSalesTable();
-  renderDocuments();
+function dashboardVisible() {
+  return !dashboardScreen.classList.contains('hidden');
 }
 
-function renderSalesTable() {
-  salesTableBody.innerHTML = '';
-  state.sales.forEach((row) => {
-    const tr = document.createElement('tr');
-    ['구분', '건수', '공급가액', '세액'].forEach((key) => {
-      const td = document.createElement('td');
-      const value = row[key];
-      td.textContent = typeof value === 'number' && key !== '건수' ? formatKRW(value, false) : value;
-      tr.appendChild(td);
-    });
-    salesTableBody.appendChild(tr);
-  });
-}
-
-function renderDocuments() {
-  documentsGrid.innerHTML = '';
-  state.sales.forEach((item) => {
-    const card = document.createElement('article');
-    card.className = 'document-card';
-
-    const icon = document.createElement('div');
-    icon.className = 'document-icon';
-    icon.textContent = getIcon(item.구분);
-    card.appendChild(icon);
-
-    const title = document.createElement('h3');
-    title.className = 'document-title';
-    title.textContent = item.구분;
-    card.appendChild(title);
-
-    const count = document.createElement('div');
-    count.className = 'document-count';
-    count.textContent = `${item.건수}건`;
-    card.appendChild(count);
-
-    const amount = document.createElement('div');
-    amount.className = 'document-amount';
-    amount.textContent = formatKRW(item.공급가액 + item.세액);
-    card.appendChild(amount);
-
-    const button = document.createElement('button');
-    button.className = 'btn-outline';
-    button.textContent = '상세보기';
-    button.type = 'button';
-    card.appendChild(button);
-
-    documentsGrid.appendChild(card);
-  });
-}
-
-function getIcon(type) {
-  switch (type) {
-    case '세금계산서':
-      return '📄';
-    case '계산서':
-      return '🧾';
-    case '카드':
-      return '💳';
-    case '현금영수증':
-      return '🧾';
-    default:
-      return '📦';
-  }
-}
-
-function formatKRW(value, withSymbol = true) {
-  const formatted = new Intl.NumberFormat('ko-KR', {
-    style: 'currency',
-    currency: 'KRW',
-    maximumFractionDigits: 0
-  }).format(value || 0);
-  return withSymbol ? formatted : formatted.replace('₩', '');
+function clearLoginForm() {
+  loginId.value = '';
+  loginPw.value = '';
+  keepLogin.checked = false;
 }

--- a/script.js
+++ b/script.js
@@ -1,96 +1,69 @@
-// 상태
 const state = {
   user: null,
-  consent: { scrape: false, privacy: false },
-  sales: [],
-  purchases: [],
-  returnDoc: null,
-  accounts: [
-    {
-      type: '개인사업자',
-      owner: '정지인 대표님',
-      amount: 1234567,
-      status: '환급 예상',
-      buttons: [
-        { label: '환급신청', style: 'btn-light' },
-        { label: '정기세 신고', style: 'btn-outline' }
-      ]
-    },
-    {
-      type: '개인사업자',
-      owner: '김유린 대표님',
-      amount: 1234567,
-      status: '환급 예정 D-70',
-      buttons: [{ label: '결제수단 등록', style: 'btn-tonal' }]
-    },
-    {
-      type: '개인사업자',
-      owner: '김아름 대표님',
-      amount: 1234567,
-      status: '환급 확정',
-      buttons: [
-        { label: '결제대기', style: 'btn-outline' },
-        { label: '입금계좌', style: 'btn-tonal' }
-      ]
-    },
-    {
-      type: '개인사업자',
-      owner: '강지윤 대표님',
-      amount: 1234567,
-      status: '환급 확정',
-      buttons: [{ label: '입금계좌', style: 'btn-tonal' }]
-    }
+  company: {
+    name: '(주) 바이브코딩',
+    type: '법인사업자',
+    regNum: '123-45-67890'
+  },
+  vat: {
+    period: '2024년 1분기',
+    amount: 1234567,
+    tax: 123456,
+    status: '신고완료'
+  },
+  sales: [
+    { 구분: '세금계산서', 건수: 15, 공급가액: 2345678, 세액: 234568 },
+    { 구분: '계산서', 건수: 8, 공급가액: 1234567, 세액: 123457 },
+    { 구분: '카드', 건수: 45, 공급가액: 4567890, 세액: 456789 },
+    { 구분: '현금영수증', 건수: 23, 공급가액: 3456789, 세액: 345679 },
+    { 구분: '그 외', 건수: 5, 공급가액: 456789, 세액: 45679 }
   ]
 };
 
-// 엘리먼트
 const loginScreen = document.getElementById('loginScreen');
 const dashboardScreen = document.getElementById('dashboardScreen');
 const btnKakao = document.getElementById('btnKakao');
 const btnSignIn = document.getElementById('btnSignIn');
-const userName = document.getElementById('userName');
-const accountList = document.getElementById('accountList');
+const btnLogout = document.getElementById('btnLogout');
 
-const btnConsent = document.getElementById('btnConsent');
-const btnConnectHometax = document.getElementById('btnConnectHometax');
-const btnMakeReturn = document.getElementById('btnMakeReturn');
-const btnDownloadXml = document.getElementById('btnDownloadXml');
-const btnDownloadPdf = document.getElementById('btnDownloadPdf');
-const btnSubmitHometax = document.getElementById('btnSubmitHometax');
+const loginId = document.getElementById('loginId');
+const loginPw = document.getElementById('loginPw');
+const keepLogin = document.getElementById('keepLogin');
 
-// 유틸
-const $ = (sel) => document.querySelector(sel);
-function show(selector, on = true) {
-  const el = typeof selector === 'string' ? $(selector) : selector;
-  if (!el) return;
-  el.classList[on ? 'remove' : 'add']('hidden');
-}
-function formatKRW(value, withSymbol = true) {
-  const formatted = new Intl.NumberFormat('ko-KR', {
-    style: 'currency',
-    currency: 'KRW',
-    maximumFractionDigits: 0
-  }).format(value || 0);
-  return withSymbol ? formatted : formatted.replace('₩', '');
-}
-function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+const welcomeMessage = document.getElementById('welcomeMessage');
+const companyName = document.getElementById('companyName');
+const companyType = document.getElementById('companyType');
+const companyRegNum = document.getElementById('companyRegNum');
+const vatPeriod = document.getElementById('vatPeriod');
+const vatAmount = document.getElementById('vatAmount');
+const vatTax = document.getElementById('vatTax');
+const vatStatus = document.getElementById('vatStatus');
+const salesTableBody = document.querySelector('#salesTable tbody');
+const documentsGrid = document.getElementById('documentsGrid');
 
-// 로그인
-btnKakao.addEventListener('click', () => completeLogin('홍길동'));
+btnKakao.addEventListener('click', () => completeLogin('카카오 사용자'));
 btnSignIn.addEventListener('click', () => {
-  const name = document.getElementById('loginId').value.trim() || '대표님';
+  const name = loginId.value.trim() || '대표님';
   completeLogin(name);
+});
+
+btnLogout.addEventListener('click', () => {
+  state.user = null;
+  loginId.value = '';
+  loginPw.value = '';
+  keepLogin.checked = false;
+  dashboardScreen.classList.add('hidden');
+  loginScreen.classList.remove('hidden');
 });
 
 function completeLogin(name) {
   state.user = { name };
-  userName.textContent = state.user.name;
-  $('#loginId').value = '';
-  $('#loginPw').value = '';
-  $('#keepLogin').checked = false;
-  renderAccounts();
+  welcomeMessage.textContent = `${state.user.name}님, 환영해요!`;
+  loginId.value = '';
+  loginPw.value = '';
+  keepLogin.checked = false;
+  renderDashboard();
   toggleScreens();
-  resetWorkflow();
 }
 
 function toggleScreens() {
@@ -98,188 +71,88 @@ function toggleScreens() {
   dashboardScreen.classList.remove('hidden');
 }
 
-// 동의 → 홈택스
-btnConsent.addEventListener('click', () => {
-  state.consent.scrape = $('#agreeScrape').checked;
-  state.consent.privacy = $('#agreePrivacy').checked;
-  if (!(state.consent.scrape && state.consent.privacy)) {
-    alert('모든 동의 항목을 체크해 주세요.');
-    return;
-  }
-  show('#consent-section', false);
-  show('#hometax-section', true);
-});
-
-btnConnectHometax.addEventListener('click', async () => {
-  $('#hometaxStatus').textContent = '연결 시도 중';
-  await sleep(500);
-  $('#hometaxStatus').textContent = '인증 성공(데모)';
-  show('#hometax-section', false);
-  show('#progress-section', true);
-  startScrapeDemo();
-});
-
-// 스크래핑 진행 시뮬레이터
-async function startScrapeDemo() {
-  const log = (t) => ($('#progressLog').innerHTML += `<div>${new Date().toLocaleTimeString()} • ${t}</div>`);
-  for (let i = 0; i <= 100; i += 20) {
-    $('#scrapeProgress').value = i;
-    log(`${i}% 완료`);
-    await sleep(400);
-  }
-  state.sales = [
-    { 구분: '전자세금계산서', 공급가액: 12000000, 세액: 1200000, 건수: 12 },
-    { 구분: '세금계산서',     공급가액:  3000000, 세액:  300000, 건수:  3 },
-    { 구분: '카드',           공급가액:  5000000, 세액:  500000, 건수: 50 },
-    { 구분: '현금영수증',     공급가액:   800000, 세액:   80000, 건수:  8 },
-    { 구분: '그외',           공급가액:   200000, 세액:   20000, 건수:  2 }
-  ];
-  state.purchases = [
-    { 구분: '전자세금계산서', 공급가액: 7000000, 세액: 700000, 건수: 10 },
-    { 구분: '신용카드',       공급가액: 2000000, 세액: 200000, 건수: 25 },
-    { 구분: '현금영수증',     공급가액:  600000, 세액:  60000, 건수:  7 }
-  ];
-  renderPreview();
+function renderDashboard() {
+  companyName.textContent = state.company.name;
+  companyType.textContent = state.company.type;
+  companyRegNum.textContent = state.company.regNum;
+  vatPeriod.textContent = state.vat.period;
+  vatAmount.textContent = formatKRW(state.vat.amount);
+  vatTax.textContent = formatKRW(state.vat.tax);
+  vatStatus.textContent = state.vat.status;
+  renderSalesTable();
+  renderDocuments();
 }
 
-function renderPreview() {
-  const salesTotal = state.sales.reduce((s, r) => s + r.공급가액 + r.세액, 0);
-  const purchaseTotal = state.purchases.reduce((s, r) => s + r.공급가액 + r.세액, 0);
-  $('#salesTotal').textContent = formatKRW(salesTotal);
-  $('#purchaseTotal').textContent = formatKRW(purchaseTotal);
-  renderTable('#salesTable', ['구분','공급가액','세액','건수'], state.sales);
-  renderTable('#purchaseTable', ['구분','공급가액','세액','건수'], state.purchases);
-  show('#progress-section', false);
-  show('#preview-section', true);
-}
-
-function renderTable(selector, headers, rows) {
-  const el = typeof selector === 'string' ? $(selector) : selector;
-  if (!el) return;
-  el.innerHTML = '';
-
-  const thead = document.createElement('thead');
-  const headerRow = document.createElement('tr');
-  headers.forEach((h) => {
-    const th = document.createElement('th');
-    th.textContent = h;
-    headerRow.appendChild(th);
-  });
-  thead.appendChild(headerRow);
-
-  const tbody = document.createElement('tbody');
-  rows.forEach((row) => {
+function renderSalesTable() {
+  salesTableBody.innerHTML = '';
+  state.sales.forEach((row) => {
     const tr = document.createElement('tr');
-    headers.forEach((h) => {
+    ['구분', '건수', '공급가액', '세액'].forEach((key) => {
       const td = document.createElement('td');
-      if (h in row) {
-        const v = row[h];
-        td.textContent = typeof v === 'number' ? formatKRW(v, false) : String(v);
-      } else {
-        td.textContent = '';
-      }
+      const value = row[key];
+      td.textContent = typeof value === 'number' && key !== '건수' ? formatKRW(value, false) : value;
       tr.appendChild(td);
     });
-    tbody.appendChild(tr);
+    salesTableBody.appendChild(tr);
   });
-
-  el.appendChild(thead);
-  el.appendChild(tbody);
 }
 
-// 신고서 생성/다운로드/제출
-btnMakeReturn.addEventListener('click', () => {
-  const salesTax = state.sales.reduce((s, r) => s + r.세액, 0);
-  const purchaseTax = state.purchases.reduce((s, r) => s + r.세액, 0);
-  const payable = Math.max(0, salesTax - purchaseTax);
-  state.returnDoc = { 매출세액: salesTax, 매입세액: purchaseTax, 납부세액: payable };
-
-  const ul = $('#returnSummary');
-  ul.innerHTML = '';
-  Object.entries(state.returnDoc).forEach(([k, v]) => {
-    const li = document.createElement('li');
-    li.textContent = `${k}: ${formatKRW(v)}`;
-    ul.appendChild(li);
-  });
-
-  show('#preview-section', false);
-  show('#return-section', true);
-});
-
-btnDownloadXml.addEventListener('click', () => alert('데모: XML 생성은 서버 구현이 필요합니다.'));
-btnDownloadPdf.addEventListener('click', () => window.print());
-btnSubmitHometax.addEventListener('click', async () => {
-  $('#submitStatus').textContent = '제출 중(데모)';
-  await sleep(800);
-  $('#submitStatus').textContent = '제출 완료(데모)';
-});
-
-// 계정 카드 렌더
-function renderAccounts() {
-  accountList.innerHTML = '';
-  state.accounts.forEach((a) => {
+function renderDocuments() {
+  documentsGrid.innerHTML = '';
+  state.sales.forEach((item) => {
     const card = document.createElement('article');
-    card.className = 'account-card';
+    card.className = 'document-card';
 
-    const meta = document.createElement('div');
-    meta.className = 'account-meta';
-    const badge = document.createElement('span');
-    badge.className = 'badge';
-    badge.textContent = a.type;
-    meta.appendChild(badge);
-    card.appendChild(meta);
+    const icon = document.createElement('div');
+    icon.className = 'document-icon';
+    icon.textContent = getIcon(item.구분);
+    card.appendChild(icon);
 
-    const owner = document.createElement('div');
-    owner.className = 'account-owner';
-    owner.textContent = a.owner;
-    card.appendChild(owner);
+    const title = document.createElement('h3');
+    title.className = 'document-title';
+    title.textContent = item.구분;
+    card.appendChild(title);
+
+    const count = document.createElement('div');
+    count.className = 'document-count';
+    count.textContent = `${item.건수}건`;
+    card.appendChild(count);
 
     const amount = document.createElement('div');
-    amount.className = 'account-amount';
-    amount.textContent = formatKRW(a.amount);
+    amount.className = 'document-amount';
+    amount.textContent = formatKRW(item.공급가액 + item.세액);
     card.appendChild(amount);
 
-    const status = document.createElement('div');
-    status.className = 'account-status';
-    status.textContent = a.status;
-    card.appendChild(status);
+    const button = document.createElement('button');
+    button.className = 'btn-outline';
+    button.textContent = '상세보기';
+    button.type = 'button';
+    card.appendChild(button);
 
-    if (a.buttons?.length) {
-      const actions = document.createElement('div');
-      actions.className = 'account-actions';
-      a.buttons.forEach((b) => {
-        const btn = document.createElement('button');
-        btn.className = b.style;
-        btn.textContent = b.label;
-        actions.appendChild(btn);
-      });
-      card.appendChild(actions);
-    }
-    accountList.appendChild(card);
+    documentsGrid.appendChild(card);
   });
 }
 
-function resetWorkflow() {
-  $('#agreeScrape').checked = false;
-  $('#agreePrivacy').checked = false;
-  $('#hometaxStatus').textContent = '';
-  $('#scrapeProgress').value = 0;
-  $('#progressLog').innerHTML = '';
-  $('#salesTotal').textContent = '-';
-  $('#purchaseTotal').textContent = '-';
-  $('#salesTable').innerHTML = '';
-  $('#purchaseTable').innerHTML = '';
-  $('#returnSummary').innerHTML = '';
-  $('#submitStatus').textContent = '';
+function getIcon(type) {
+  switch (type) {
+    case '세금계산서':
+      return '📄';
+    case '계산서':
+      return '🧾';
+    case '카드':
+      return '💳';
+    case '현금영수증':
+      return '🧾';
+    default:
+      return '📦';
+  }
+}
 
-  state.consent = { scrape: false, privacy: false };
-  state.sales = [];
-  state.purchases = [];
-  state.returnDoc = null;
-
-  show('#consent-section', true);
-  show('#hometax-section', false);
-  show('#progress-section', false);
-  show('#preview-section', false);
-  show('#return-section', false);
+function formatKRW(value, withSymbol = true) {
+  const formatted = new Intl.NumberFormat('ko-KR', {
+    style: 'currency',
+    currency: 'KRW',
+    maximumFractionDigits: 0
+  }).format(value || 0);
+  return withSymbol ? formatted : formatted.replace('₩', '');
 }

--- a/styles.css
+++ b/styles.css
@@ -1,19 +1,19 @@
 :root {
   --bg-body: #f5f6fb;
   --bg-card: #ffffff;
-  --bg-kakao: #fee500;
   --bg-primary: linear-gradient(180deg, #f8fbff 0%, #eef4ff 100%);
   --text-main: #1b1d29;
   --text-muted: #6f7385;
   --accent: #3d63ff;
-  --pill-bg: rgba(61, 99, 255, 0.12);
-  --pill-text: #3d63ff;
+  --accent-dark: #2b4ed4;
   --border-soft: #e5e8f0;
-  --shadow-soft: 0 20px 40px rgba(27, 29, 41, 0.08);
+  --shadow-soft: 0 18px 40px rgba(27, 29, 41, 0.1);
   font-family: 'Pretendard', 'Apple SD Gothic Neo', 'Segoe UI', sans-serif;
 }
 
-* { box-sizing: border-box; }
+* {
+  box-sizing: border-box;
+}
 
 body {
   margin: 0;
@@ -21,9 +21,20 @@ body {
   color: var(--text-main);
 }
 
-.app { min-height: 100vh; }
-.screen { min-height: 100vh; padding: 24px 20px 40px; }
-.screen-login { display: flex; align-items: center; justify-content: center; }
+.app {
+  min-height: 100vh;
+}
+
+.screen {
+  min-height: 100vh;
+  padding: 32px 20px 48px;
+}
+
+.screen-login {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 
 .login-card {
   width: min(360px, 100%);
@@ -36,98 +47,291 @@ body {
   gap: 18px;
 }
 
-.login-brand { font-size: 22px; font-weight: 700; text-align: center; }
-.login-title { margin: 0; font-size: 18px; line-height: 1.4; text-align: center; }
-.login-subtitle { margin: 0; font-size: 14px; color: var(--text-muted); }
-
-.btn { border: none; border-radius: 14px; font-size: 15px; font-weight: 600; padding: 15px; cursor: pointer; }
-.btn-kakao { background: var(--bg-kakao); color: #191600; }
-.btn-login { background: var(--accent); color: #fff; }
-.btn-add { background: rgba(255,255,255,.28); color:#fff; padding:12px 16px; font-size:14px; border-radius:999px; box-shadow: inset 0 0 0 1px rgba(255,255,255,.4); }
-
-input[type="text"], input[type="password"] {
-  width: 100%; padding: 14px 16px; border-radius: 14px; border: 1px solid var(--border-soft); background: #fafbff; font-size: 15px;
+.login-brand {
+  font-size: 22px;
+  font-weight: 700;
+  text-align: center;
 }
-.input-label { font-size: 13px; color: var(--text-muted); }
-.remember { display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--text-muted); }
 
-.login-links { display: flex; justify-content: space-between; font-size: 13px; }
-.login-links a { color: var(--text-muted); text-decoration: none; }
-
-.divider { display:flex; align-items:center; justify-content:center; gap:16px; color:var(--text-muted); font-size:13px; }
-.divider::before, .divider::after { content:""; flex:1; height:1px; background: var(--border-soft); }
-
-.screen-dashboard { background: var(--bg-primary); display:flex; flex-direction:column; gap:18px; }
-.dash-header { display:flex; justify-content:space-between; align-items:flex-start; gap:16px; }
-.dash-subtitle { margin:0; font-size:14px; color:var(--text-muted); }
-.dash-title { margin:8px 0 0; font-size:24px; line-height:1.35; }
-
-.pill-tabs { display:flex; gap:12px; }
-.pill { padding:10px 18px; border-radius:999px; background:#fff; color:var(--text-muted); font-size:14px; border:none; }
-.pill.is-active { background: var(--pill-bg); color: var(--pill-text); font-weight:600; }
-
-.notice { background:#fff5ec; padding:14px 18px; border-radius:18px; color:#ff7a00; font-size:13px; align-self:flex-start; box-shadow:0 12px 30px rgba(255,122,0,.18); }
-
-.account-list { display:flex; flex-direction:column; gap:16px; }
-.account-card { background:var(--bg-card); border-radius:22px; padding:24px; box-shadow:var(--shadow-soft); display:flex; flex-direction:column; gap:18px; }
-.account-meta { display:flex; justify-content:space-between; align-items:center; }
-.badge { padding:6px 12px; border-radius:999px; font-size:12px; font-weight:600; background: rgba(61,99,255,.12); color: var(--pill-text); }
-.account-owner { font-size:18px; font-weight:700; }
-.account-amount { font-size:28px; font-weight:700; }
-.account-status { font-size:13px; color: var(--text-muted); }
-.account-actions { display:flex; gap:12px; flex-wrap:wrap; }
-
-.btn-light, .btn-outline, .btn-tonal {
-  flex:1; min-width:140px; padding:12px; border-radius:14px; font-size:14px; font-weight:600; cursor:pointer; border:none;
+.login-title {
+  margin: 0;
+  font-size: 18px;
+  line-height: 1.4;
+  text-align: center;
 }
-.btn-outline { background:#f3f5ff; color:var(--pill-text); }
-.btn-tonal { background:#e7f7ff; color:#0088cc; }
-.btn-light { background:#fff7eb; color:#f27a06; }
 
-.hidden { display: none !important; }
+.login-subtitle {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text-muted);
+}
 
-.workflow { display:flex; flex-direction:column; gap:18px; margin-top:8px; padding-bottom:48px; }
-.workflow-header { display:flex; flex-direction:column; gap:6px; }
-.workflow-title { margin:0; font-size:20px; }
-.workflow-subtitle { margin:0; font-size:13px; color:var(--text-muted); line-height:1.5; }
+.input-label {
+  font-size: 13px;
+  color: var(--text-muted);
+}
 
-.workflow-card { background:var(--bg-card); border-radius:20px; padding:22px 20px; box-shadow:var(--shadow-soft); display:flex; flex-direction:column; gap:16px; }
-.workflow-card h3, .workflow-card h4 { margin:0; }
+input[type="text"],
+input[type="password"] {
+  width: 100%;
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 1px solid var(--border-soft);
+  background: #fafbff;
+  font-size: 15px;
+}
 
-.wf-checkbox { display:flex; align-items:flex-start; gap:10px; font-size:14px; color:var(--text-main); }
-.wf-checkbox input { margin-top:3px; }
+.remember {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
 
-.wf-radio-group { display:flex; gap:12px; flex-wrap:wrap; }
-.wf-radio { display:flex; align-items:center; gap:8px; font-size:14px; padding:10px 14px; border-radius:14px; background:#f3f4fb; }
-.wf-radio input { margin:0; }
+.btn {
+  border: none;
+  border-radius: 14px;
+  font-size: 15px;
+  font-weight: 600;
+  padding: 15px;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
 
-.wf-muted { margin:0; font-size:13px; color:var(--text-muted); }
-.wf-row { display:flex; align-items:center; gap:12px; flex-wrap:wrap; }
-.wf-status { font-size:13px; color:var(--text-muted); }
-.wf-tip { margin:0; font-size:12px; color:var(--text-muted); }
+.btn:active {
+  transform: translateY(1px);
+}
 
-.wf-btn { border:none; border-radius:14px; padding:14px 18px; font-size:15px; font-weight:600; cursor:pointer; transition: transform .2s ease; }
-.wf-btn:active { transform: translateY(1px); }
-.wf-btn-primary { background: var(--accent); color:#fff; }
-.wf-btn-secondary { background:#eef2ff; color: var(--pill-text); }
-.wf-btn-outline { background:#fff; color: var(--accent); box-shadow: inset 0 0 0 1px rgba(61,99,255,.3); }
+.btn-kakao {
+  background: #fee500;
+  color: #191600;
+}
 
-.wf-progress { width:100%; height:8px; border-radius:999px; overflow:hidden; accent-color: var(--accent); }
-.wf-log { min-height:100px; max-height:160px; overflow-y:auto; border-radius:14px; padding:12px; background:#f6f8ff; font-size:13px; color:var(--text-muted); }
+.btn-login {
+  background: var(--accent);
+  color: #fff;
+}
 
-.wf-grid { display:grid; gap:18px; }
-.wf-kpi { font-size:22px; font-weight:700; margin:4px 0 0; }
+.btn-primary {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 0 10px 20px rgba(61, 99, 255, 0.25);
+}
 
-.wf-table { width:100%; border-collapse:collapse; font-size:13px; }
-.wf-table th, .wf-table td { text-align:left; padding:8px 0; border-bottom:1px solid var(--border-soft); }
+.btn-secondary {
+  background: rgba(255, 255, 255, 0.18);
+  color: var(--accent);
+  border: 1px solid rgba(61, 99, 255, 0.28);
+}
 
-.wf-list { margin:0; padding-left:18px; font-size:14px; color:var(--text-main); display:flex; flex-direction:column; gap:4px; }
-.wf-actions { display:flex; flex-direction:column; gap:10px; }
+.login-links {
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+}
 
-@media (min-width: 600px) { .wf-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+.login-links a {
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.divider {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.divider::before,
+.divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--border-soft);
+}
+
+.screen-dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  background: var(--bg-primary);
+}
+
+.company-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: 24px;
+  padding: 24px;
+  box-shadow: var(--shadow-soft);
+}
+
+.welcome {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
+.company-name {
+  margin: 6px 0 12px;
+  font-size: 26px;
+  line-height: 1.3;
+}
+
+.company-info {
+  display: flex;
+  gap: 12px;
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
+.company-type {
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(61, 99, 255, 0.12);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.company-reg-num {
+  align-self: center;
+}
+
+.section-title {
+  margin: 0 0 16px;
+  font-size: 20px;
+}
+
+.vat-report-section,
+.sales-section,
+.documents-section {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 24px;
+  padding: 24px;
+  box-shadow: var(--shadow-soft);
+}
+
+.vat-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 18px;
+}
+
+.vat-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.vat-label {
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.vat-value {
+  font-size: 17px;
+  font-weight: 600;
+}
+
+.vat-value.amount {
+  font-size: 20px;
+}
+
+.vat-value.status {
+  color: #1eb980;
+}
+
+.sales-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.sales-table th,
+.sales-table td {
+  padding: 12px 8px;
+  text-align: left;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.sales-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.documents-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 18px;
+}
+
+.document-card {
+  background: #fff;
+  border-radius: 20px;
+  padding: 20px;
+  box-shadow: 0 16px 32px rgba(27, 29, 41, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.document-icon {
+  font-size: 28px;
+}
+
+.document-title {
+  margin: 0;
+  font-size: 18px;
+}
+
+.document-count {
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
+.document-amount {
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.btn-outline {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid rgba(61, 99, 255, 0.3);
+  padding: 10px 14px;
+  border-radius: 12px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.hidden {
+  display: none !important;
+}
+
 @media (min-width: 768px) {
-  .screen { padding: 40px 48px 64px; }
-  .dash-header { align-items: center; }
-  .account-list { flex-direction: row; flex-wrap: wrap; }
-  .account-card { width: calc(50% - 8px); }
+  .screen {
+    padding: 48px 60px 72px;
+  }
+
+  .company-header {
+    align-items: center;
+  }
+
+  .welcome {
+    font-size: 16px;
+  }
+
+  .company-name {
+    font-size: 32px;
+  }
+
+  .section-title {
+    font-size: 22px;
+  }
 }


### PR DESCRIPTION
## Summary
- 로그인 이후 화면을 새 디자인으로 교체하고 회사 및 신고 정보를 한눈에 볼 수 있게 구성했습니다.
- 매출 구분별 표와 카드형 요약을 "세금계산서, 계산서, 카드, 현금영수증, 그 외" 순서로 자동으로 렌더링하도록 스크립트를 재구성했습니다.
- 새로운 UI에 맞춰 스타일을 전체적으로 손보고 환영 문구와 로그아웃 버튼을 추가했습니다.

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e638ba1650832abfa20c232c346fa8